### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+---
+language: python
+python: 3.6
+
+sudo: required
+services:
+  - docker
+
+env:
+  - CONTEXT=.
+  - CONTEXT=0.9.0
+
+script:
+  - docker build $CONTEXT
+
+stages:
+  - lint python code
+  - verify update was run
+  - test
+
+jobs:
+  include:
+    - stage: lint python code
+      install: pip install tox-travis
+      script: tox
+
+    - stage: verify update was run
+      script:
+        - ./update.py
+        - test -z "$(git status -s)"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ ModuleSync
 
 [![dockeri.co](http://dockeri.co/image/vshn/modulesync)](https://hub.docker.com/r/vshn/modulesync/)
 
-[![MIT License](https://img.shields.io/github/license/vshn/docker-modulesync.svg)](https://github.com/vshn/docker-modulesync/blob/master/LICENSE
+[![Build Status](https://img.shields.io/travis/vshn/docker-modulesync.png)](https://travis-ci.org/vshn/docker-modulesync
+) [![MIT License](https://img.shields.io/github/license/vshn/docker-modulesync.svg)](https://github.com/vshn/docker-modulesync/blob/master/LICENSE
 ) [![GitHub issues](https://img.shields.io/github/issues-raw/vshn/docker-modulesync.svg)](https://github.com/vshn/docker-modulesync/issues
 ) [![GitHub PRs](https://img.shields.io/github/issues-pr-raw/vshn/docker-modulesync.svg)](https://github.com/vshn/docker-modulesync/pulls)
 


### PR DESCRIPTION
This is a minimal quality gate to ensure that

- the included Python code satisfies established conventions, and
- that the Docker builds won't fail on Docker Hub later.