### PR TITLE
Make sure Tox runs all envs (i.e. flake8 and pylint)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ stages:
 jobs:
   include:
     - stage: lint python code
-      install: pip install tox-travis
+      install: pip install tox
       script: tox
 
     - stage: verify update was run


### PR DESCRIPTION
The `tox-travis` Python package sets and evaluates the `TOXENV` environment variable, which leads to the build running an - undefined - `py36` Tox env, instead of the two linter envs defined in `tox.ini`.

This PR fixes that by installing the plain `tox` package.