### PR TITLE
Release 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ services:
 
 env:
   - CONTEXT=.
+  - CONTEXT=1.0.0
   - CONTEXT=0.10.0
   - CONTEXT=0.9.0
 

--- a/0.10.0/Dockerfile
+++ b/0.10.0/Dockerfile
@@ -6,11 +6,14 @@ WORKDIR /app
 
 RUN adduser --disabled-password --gecos '' msync \
  && apt-get update \
- && apt-get install -y build-essential git \
+ && apt-get install -y --no-install-recommends \
+      build-essential \
+      git \
  && gem install modulesync --version 0.10.0 \
  && apt-get purge -y build-essential \
  && apt-get autoremove --purge -y \
- && apt-get clean
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 USER msync
 

--- a/0.9.0/Dockerfile
+++ b/0.9.0/Dockerfile
@@ -6,11 +6,14 @@ WORKDIR /app
 
 RUN adduser --disabled-password --gecos '' msync \
  && apt-get update \
- && apt-get install -y build-essential git \
+ && apt-get install -y --no-install-recommends \
+      build-essential \
+      git \
  && gem install modulesync --version 0.9.0 \
  && apt-get purge -y build-essential \
  && apt-get autoremove --purge -y \
- && apt-get clean
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 USER msync
 

--- a/1.0.0/Dockerfile
+++ b/1.0.0/Dockerfile
@@ -1,0 +1,17 @@
+FROM ruby:2.5-slim
+
+LABEL maintainer="VSHN AG <tech@vshn.ch>"
+
+WORKDIR /app
+
+RUN adduser --disabled-password --gecos '' msync \
+ && apt-get update \
+ && apt-get install -y build-essential git \
+ && gem install modulesync --version 1.0.0 \
+ && apt-get purge -y build-essential \
+ && apt-get autoremove --purge -y \
+ && apt-get clean
+
+USER msync
+
+CMD ["msync"]

--- a/1.0.0/Dockerfile
+++ b/1.0.0/Dockerfile
@@ -6,11 +6,14 @@ WORKDIR /app
 
 RUN adduser --disabled-password --gecos '' msync \
  && apt-get update \
- && apt-get install -y build-essential git \
+ && apt-get install -y --no-install-recommends \
+      build-essential \
+      git \
  && gem install modulesync --version 1.0.0 \
  && apt-get purge -y build-essential \
  && apt-get autoremove --purge -y \
- && apt-get clean
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 USER msync
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ WORKDIR /app
 
 RUN adduser --disabled-password --gecos '' msync \
  && apt-get update \
- && apt-get install -y build-essential git \
+ && apt-get install -y --no-install-recommends \
+      build-essential \
+      git \
  && git clone --depth=1 https://github.com/voxpupuli/modulesync.git \
  && cd modulesync \
  && gem build modulesync.gemspec \
@@ -14,6 +16,7 @@ RUN adduser --disabled-password --gecos '' msync \
  && apt-get purge -y build-essential \
  && apt-get autoremove --purge -y \
  && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* \
  && cd .. \
  && rm -rf modulesync
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Supported Tags
   https://microbadger.com/images/vshn/modulesync:latest) [![based on](
   https://img.shields.io/badge/Git-master-grey.svg?colorA=5a5b5c&colorB=9a9b9c&logo=github)](
   https://github.com/voxpupuli/modulesync)
+- [![1.0.0](
+  https://img.shields.io/badge/1.0.0-blue.svg?colorA=22313f&colorB=4a637b&logo=docker)](
+  https://github.com/vshn/docker-modulesync/blob/master/1.0.0/Dockerfile) [![size/layers](
+  https://images.microbadger.com/badges/image/vshn/modulesync:1.0.0.svg)](
+  https://microbadger.com/images/vshn/modulesync:1.0.0) [![based on](
+  https://img.shields.io/badge/Gem-1.0.0-red.svg?colorA=ff919f&colorB=9a9b9c&logo=ruby)](
+  https://rubygems.org/gems/modulesync/versions/1.0.0)
 - [![0.10.0](
   https://img.shields.io/badge/0.10.0-blue.svg?colorA=22313f&colorB=4a637b&logo=docker)](
   https://github.com/vshn/docker-modulesync/blob/master/0.10.0/Dockerfile) [![size/layers](

--- a/update.py
+++ b/update.py
@@ -32,11 +32,14 @@ def create_dockerfile(ver):
     build_commands_needle = ' && apt-get update '
     install_commands = [
         f" && apt-get update \\",
-        f" && apt-get install -y build-essential git \\",
+        f" && apt-get install -y --no-install-recommends \\",
+        f"      build-essential \\",
+        f"      git \\",
         f" && gem install modulesync --version {ver} \\",
         f" && apt-get purge -y build-essential \\",
         f" && apt-get autoremove --purge -y \\",
-        f" && apt-get clean",
+        f" && apt-get clean \\",
+        f" && rm -rf /var/lib/apt/lists/*",
     ]
 
     makedirs(ver, exist_ok=True)

--- a/update.py
+++ b/update.py
@@ -7,6 +7,7 @@ from os import makedirs, path
 VERSIONS = [
     '0.9.0',
     '0.10.0',
+    '1.0.0',
     # add new versions here
 ]
 DOCKER_IMAGE = 'vshn/modulesync'


### PR DESCRIPTION
Integrates the new ModuleSync 1.0.0 release:

- [Related upstream PR](https://github.com/voxpupuli/modulesync/pull/170)
- [Released Gem v1.0.0](https://rubygems.org/gems/modulesync/versions/1.0.0)