### PR TITLE
Generate Docker images for v1.1.0 through v1.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ services:
 
 env:
   - CONTEXT=.
+  - CONTEXT=1.3.0
+  - CONTEXT=1.2.0
+  - CONTEXT=1.1.0
   - CONTEXT=1.0.0
   - CONTEXT=0.10.0
   - CONTEXT=0.9.0

--- a/1.1.0/Dockerfile
+++ b/1.1.0/Dockerfile
@@ -1,0 +1,20 @@
+FROM ruby:2.5-slim
+
+LABEL maintainer="VSHN AG <tech@vshn.ch>"
+
+WORKDIR /app
+
+RUN adduser --disabled-password --gecos '' msync \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+      build-essential \
+      git \
+ && gem install modulesync --version 1.1.0 \
+ && apt-get purge -y build-essential \
+ && apt-get autoremove --purge -y \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+USER msync
+
+CMD ["msync"]

--- a/1.2.0/Dockerfile
+++ b/1.2.0/Dockerfile
@@ -1,0 +1,20 @@
+FROM ruby:2.5-slim
+
+LABEL maintainer="VSHN AG <tech@vshn.ch>"
+
+WORKDIR /app
+
+RUN adduser --disabled-password --gecos '' msync \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+      build-essential \
+      git \
+ && gem install modulesync --version 1.2.0 \
+ && apt-get purge -y build-essential \
+ && apt-get autoremove --purge -y \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+USER msync
+
+CMD ["msync"]

--- a/1.3.0/Dockerfile
+++ b/1.3.0/Dockerfile
@@ -1,0 +1,20 @@
+FROM ruby:2.5-slim
+
+LABEL maintainer="VSHN AG <tech@vshn.ch>"
+
+WORKDIR /app
+
+RUN adduser --disabled-password --gecos '' msync \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+      build-essential \
+      git \
+ && gem install modulesync --version 1.3.0 \
+ && apt-get purge -y build-essential \
+ && apt-get autoremove --purge -y \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+USER msync
+
+CMD ["msync"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,27 @@ Supported Tags
   https://microbadger.com/images/vshn/modulesync:latest) [![based on](
   https://img.shields.io/badge/Git-master-grey.svg?colorA=5a5b5c&colorB=9a9b9c&logo=github)](
   https://github.com/voxpupuli/modulesync)
+- [![1.3.0](
+  https://img.shields.io/badge/1.3.0-blue.svg?colorA=22313f&colorB=4a637b&logo=docker)](
+  https://github.com/vshn/docker-modulesync/blob/master/1.3.0/Dockerfile) [![size/layers](
+  https://images.microbadger.com/badges/image/vshn/modulesync:1.3.0.svg)](
+  https://microbadger.com/images/vshn/modulesync:1.3.0) [![based on](
+  https://img.shields.io/badge/Gem-1.3.0-red.svg?colorA=ff919f&colorB=9a9b9c&logo=ruby)](
+  https://rubygems.org/gems/modulesync/versions/1.3.0)
+- [![1.2.0](
+  https://img.shields.io/badge/1.2.0-blue.svg?colorA=22313f&colorB=4a637b&logo=docker)](
+  https://github.com/vshn/docker-modulesync/blob/master/1.2.0/Dockerfile) [![size/layers](
+  https://images.microbadger.com/badges/image/vshn/modulesync:1.2.0.svg)](
+  https://microbadger.com/images/vshn/modulesync:1.2.0) [![based on](
+  https://img.shields.io/badge/Gem-1.2.0-red.svg?colorA=ff919f&colorB=9a9b9c&logo=ruby)](
+  https://rubygems.org/gems/modulesync/versions/1.2.0)
+- [![1.1.0](
+  https://img.shields.io/badge/1.1.0-blue.svg?colorA=22313f&colorB=4a637b&logo=docker)](
+  https://github.com/vshn/docker-modulesync/blob/master/1.1.0/Dockerfile) [![size/layers](
+  https://images.microbadger.com/badges/image/vshn/modulesync:1.1.0.svg)](
+  https://microbadger.com/images/vshn/modulesync:1.1.0) [![based on](
+  https://img.shields.io/badge/Gem-1.1.0-red.svg?colorA=ff919f&colorB=9a9b9c&logo=ruby)](
+  https://rubygems.org/gems/modulesync/versions/1.1.0)
 - [![1.0.0](
   https://img.shields.io/badge/1.0.0-blue.svg?colorA=22313f&colorB=4a637b&logo=docker)](
   https://github.com/vshn/docker-modulesync/blob/master/1.0.0/Dockerfile) [![size/layers](

--- a/update.py
+++ b/update.py
@@ -8,6 +8,9 @@ VERSIONS = [
     '0.9.0',
     '0.10.0',
     '1.0.0',
+    '1.1.0',
+    '1.2.0',
+    '1.3.0',
     # add new versions here
 ]
 DOCKER_IMAGE = 'vshn/modulesync'
@@ -31,15 +34,15 @@ def create_dockerfile(ver):
 
     build_commands_needle = ' && apt-get update '
     install_commands = [
-        f" && apt-get update \\",
-        f" && apt-get install -y --no-install-recommends \\",
-        f"      build-essential \\",
-        f"      git \\",
+        " && apt-get update \\",
+        " && apt-get install -y --no-install-recommends \\",
+        "      build-essential \\",
+        "      git \\",
         f" && gem install modulesync --version {ver} \\",
-        f" && apt-get purge -y build-essential \\",
-        f" && apt-get autoremove --purge -y \\",
-        f" && apt-get clean \\",
-        f" && rm -rf /var/lib/apt/lists/*",
+        " && apt-get purge -y build-essential \\",
+        " && apt-get autoremove --purge -y \\",
+        " && apt-get clean \\",
+        " && rm -rf /var/lib/apt/lists/*",
     ]
 
     makedirs(ver, exist_ok=True)
@@ -102,13 +105,13 @@ def add_tag_badge_to_readme(ver):
     print(f"Updating README: tag {ver} ...")
 
     dockerfile_badge = f"https://img.shields.io/badge/{ver}-blue.svg" \
-                       f"?colorA=22313f&colorB=4a637b&logo=docker"
+                       "?colorA=22313f&colorB=4a637b&logo=docker"
     dockerfile_url = f"https://github.com/{GIT_REPO}/blob/master/{ver}/Dockerfile"
-    sizelayers_badge = f"https://images.microbadger.com/badges/image/" \
+    sizelayers_badge = "https://images.microbadger.com/badges/image/" \
                        f"{DOCKER_IMAGE}:{ver}.svg"
     sizelayers_url = f"https://microbadger.com/images/{DOCKER_IMAGE}:{ver}"
     rubygem_badge = f"https://img.shields.io/badge/Gem-{ver}-red.svg" \
-                    f"?colorA=ff919f&colorB=9a9b9c&logo=ruby"
+                    "?colorA=ff919f&colorB=9a9b9c&logo=ruby"
     rubygem_url = f"https://rubygems.org/gems/modulesync/versions/{ver}"
     tag_lines = [
         f"- [![{ver}](",
@@ -164,8 +167,8 @@ def main():
         add_tag_badge_to_readme(version)
         add_version_to_tests(version)
 
-    print(f"Done. Put the changes under version control now, "
-          f"and update your Docker image configuration at "
+    print("Done. Put the changes under version control now, "
+          "and update your Docker image configuration at "
           f"https://cloud.docker.com/u/{DOCKERHUB_USER}/repository/docker/"
           f"{DOCKER_IMAGE}/hubbuilds. Thank you!")
 


### PR DESCRIPTION
This will generate new Docker image( tag)s for the newer [modulesync versions](https://rubygems.org/gems/modulesync/versions) v1.1.0 through v1.3.0.