### PR TITLE
Release vshn/modulesync:2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ services:
 
 env:
   - CONTEXT=.
+  - CONTEXT=2.0.0
   - CONTEXT=1.3.0
   - CONTEXT=1.2.0
   - CONTEXT=1.1.0

--- a/2.0.0/Dockerfile
+++ b/2.0.0/Dockerfile
@@ -1,0 +1,20 @@
+FROM ruby:2.5-slim
+
+LABEL maintainer="VSHN AG <tech@vshn.ch>"
+
+WORKDIR /app
+
+RUN adduser --disabled-password --gecos '' msync \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+      build-essential \
+      git \
+ && gem install modulesync --version 2.0.0 \
+ && apt-get purge -y build-essential \
+ && apt-get autoremove --purge -y \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+USER msync
+
+CMD ["msync"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Supported Tags
   https://microbadger.com/images/vshn/modulesync:latest) [![based on](
   https://img.shields.io/badge/Git-master-grey.svg?colorA=5a5b5c&colorB=9a9b9c&logo=github)](
   https://github.com/voxpupuli/modulesync)
+- [![2.0.0](
+  https://img.shields.io/badge/2.0.0-blue.svg?colorA=22313f&colorB=4a637b&logo=docker)](
+  https://github.com/vshn/docker-modulesync/blob/master/2.0.0/Dockerfile) [![size/layers](
+  https://images.microbadger.com/badges/image/vshn/modulesync:2.0.0.svg)](
+  https://microbadger.com/images/vshn/modulesync:2.0.0) [![based on](
+  https://img.shields.io/badge/Gem-2.0.0-red.svg?colorA=ff919f&colorB=9a9b9c&logo=ruby)](
+  https://rubygems.org/gems/modulesync/versions/2.0.0)
 - [![1.3.0](
   https://img.shields.io/badge/1.3.0-blue.svg?colorA=22313f&colorB=4a637b&logo=docker)](
   https://github.com/vshn/docker-modulesync/blob/master/1.3.0/Dockerfile) [![size/layers](

--- a/update.py
+++ b/update.py
@@ -11,6 +11,7 @@ VERSIONS = [
     '1.1.0',
     '1.2.0',
     '1.3.0',
+    '2.0.0',
     # add new versions here
 ]
 DOCKER_IMAGE = 'vshn/modulesync'


### PR DESCRIPTION
Releases a Docker image with the latest ModuleSync release v2.0.0, as crafted at https://github.com/voxpupuli/modulesync/pull/189.